### PR TITLE
ci: fix release step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,10 @@ jobs:
   release:
     needs: [ test ]
     if: startsWith(github.ref, 'refs/tags')
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
## Description
Was missing GitHub token environment variable and the permission to write contents.
Added so it fixes the release step.